### PR TITLE
Bump dependencies

### DIFF
--- a/crfsuite-sys/Cargo.toml
+++ b/crfsuite-sys/Cargo.toml
@@ -7,7 +7,7 @@ links = "crfsuite"
 
 [build-dependencies]
 gcc = "0.3"
-bindgen = "^0.37"
+bindgen = "^0.46"
 dinghy-build = { version = "0.3", features = [ "with-bindgen" ] }
 
 [dependencies]

--- a/crfsuite-sys/Cargo.toml
+++ b/crfsuite-sys/Cargo.toml
@@ -8,7 +8,7 @@ links = "crfsuite"
 [build-dependencies]
 gcc = "0.3"
 bindgen = "^0.46"
-dinghy-build = { version = "0.3", features = [ "with-bindgen" ] }
+dinghy-build = { version = "0.4", features = [ "with-bindgen" ] }
 
 [dependencies]
 libc = "0.2"

--- a/crfsuite-sys/Cargo.toml
+++ b/crfsuite-sys/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 links = "crfsuite"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 bindgen = "^0.46"
 dinghy-build = { version = "0.4", features = [ "with-bindgen" ] }
 

--- a/crfsuite-sys/build.rs
+++ b/crfsuite-sys/build.rs
@@ -1,6 +1,3 @@
-extern crate dinghy_build;
-extern crate cc;
-
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};

--- a/crfsuite-sys/build.rs
+++ b/crfsuite-sys/build.rs
@@ -1,5 +1,5 @@
 extern crate dinghy_build;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::fs::File;
@@ -7,7 +7,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 
 fn main() {
-    gcc::Build::new()
+    cc::Build::new()
         .include("c/include")
         //.define("USE_SSE", "1") // TODO check if target supports SSE and enable if so
         // lbfgs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-extern crate failure;
-extern crate crfsuite_sys;
-extern crate libc;
-
 use std::f64;
 use std::ffi::{CStr, CString};
 use std::fs::File;
@@ -15,6 +10,7 @@ use std::slice;
 
 use crfsuite_sys::crfsuite_create_instance_from_memory;
 use crfsuite_sys::floatval_t;
+use failure::bail;
 
 type Result<T> = std::result::Result<T, failure::Error>;
 


### PR DESCRIPTION
Careful this PR breaks binary compatibility with previous versions because of `bindgen` bump.

This also replace the deprecated `gcc` crate by `cc`.