### PR TITLE
Fix compatibility issue with llvm16

### DIFF
--- a/crfsuite-sys/Cargo.toml
+++ b/crfsuite-sys/Cargo.toml
@@ -7,7 +7,7 @@ links = "crfsuite"
 
 [build-dependencies]
 cc = "1.0"
-bindgen = "0.56"
+bindgen = "0.65"
 dinghy-build = "0.4.21"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ impl Tagger {
             let x: &[u8] = data.as_ref();
             crfsuite_create_instance_from_memory(
                 x.as_ptr() as *const _,
-                data.len() as crfsuite_sys::size_t,
+                data.len() as libc::size_t,
                 &mut model,
             )
         };


### PR DESCRIPTION
- Issue:
Lib does not compile when using llvm16.0.1 (tested on Fedora 38).
[log](https://github.com/snipsco/crfsuite-rs/files/11371563/log.txt)

- Fix:
Bump `bindgen` and fix subsequent compile issue.